### PR TITLE
Overlay: block global Enter hotkey on role=textbox

### DIFF
--- a/overlay/overlay-utils.js
+++ b/overlay/overlay-utils.js
@@ -9,6 +9,13 @@
     if (!target) return false;
     const tag = String(target.tagName || "").toLowerCase();
     if (target.isContentEditable) return true;
+
+    // Support custom inputs (e.g. <div role="textbox">) so global Enter hotkeys
+    // don't accidentally trigger overlay actions while the user is typing.
+    const role = String(target.getAttribute?.("role") || "").toLowerCase();
+    const textRoles = new Set(["textbox", "searchbox", "combobox", "spinbutton"]);
+    if (textRoles.has(role)) return true;
+
     return tag === "input" || tag === "textarea" || tag === "select";
   }
 

--- a/overlay/overlay-utils.test.js
+++ b/overlay/overlay-utils.test.js
@@ -8,6 +8,15 @@ test("isTextInputTarget: recognizes common typing targets", () => {
   assert.equal(isTextInputTarget({ tagName: "textarea" }), true);
   assert.equal(isTextInputTarget({ tagName: "Select" }), true);
   assert.equal(isTextInputTarget({ tagName: "DIV", isContentEditable: true }), true);
+
+  assert.equal(
+    isTextInputTarget({ tagName: "DIV", getAttribute: (k) => (k === "role" ? "textbox" : null) }),
+    true
+  );
+  assert.equal(
+    isTextInputTarget({ tagName: "DIV", getAttribute: (k) => (k === "role" ? "combobox" : null) }),
+    true
+  );
 });
 
 test("isTextInputTarget: ignores non-input targets", () => {


### PR DESCRIPTION
Small focus-safety improvement: treat ARIA role=textbox/combobox/searchbox/spinbutton as text input targets so global Enter hotkeys don't accidentally fire overlay actions while typing in custom inputs.

- Adds unit tests in overlay-utils.test.js

Tests:
- npm --prefix overlay test