### PR TITLE
Overlay: ignore global Enter for ARIA textbox/searchbox/combobox

### DIFF
--- a/overlay/overlay-utils.js
+++ b/overlay/overlay-utils.js
@@ -9,7 +9,12 @@
     if (!target) return false;
     const tag = String(target.tagName || "").toLowerCase();
     if (target.isContentEditable) return true;
-    return tag === "input" || tag === "textarea" || tag === "select";
+
+    if (tag === "input" || tag === "textarea" || tag === "select") return true;
+
+    // ARIA roles used by many custom input widgets (e.g. Electron apps, web UIs).
+    const role = String(target.getAttribute?.("role") || "").toLowerCase();
+    return role === "textbox" || role === "searchbox" || role === "combobox";
   }
 
   // Treat common interactive elements as "hands-off" for global hotkeys.
@@ -28,7 +33,7 @@
     // element that should "own" the keyboard interaction.
     if (typeof target.closest === "function") {
       const hit = target.closest(
-        'input,textarea,select,[contenteditable="true"],button,a,[role="button"],[role="link"]'
+        'input,textarea,select,[contenteditable="true"],button,a,[role="button"],[role="link"],[role="textbox"],[role="searchbox"],[role="combobox"]'
       );
       if (hit) return hit;
     }

--- a/overlay/overlay-utils.test.js
+++ b/overlay/overlay-utils.test.js
@@ -8,6 +8,10 @@ test("isTextInputTarget: recognizes common typing targets", () => {
   assert.equal(isTextInputTarget({ tagName: "textarea" }), true);
   assert.equal(isTextInputTarget({ tagName: "Select" }), true);
   assert.equal(isTextInputTarget({ tagName: "DIV", isContentEditable: true }), true);
+
+  assert.equal(isTextInputTarget({ tagName: "DIV", getAttribute: (k) => (k === "role" ? "textbox" : null) }), true);
+  assert.equal(isTextInputTarget({ tagName: "DIV", getAttribute: (k) => (k === "role" ? "searchbox" : null) }), true);
+  assert.equal(isTextInputTarget({ tagName: "DIV", getAttribute: (k) => (k === "role" ? "combobox" : null) }), true);
 });
 
 test("isTextInputTarget: ignores non-input targets", () => {
@@ -31,6 +35,7 @@ test("isInteractiveTarget: ignores non-interactive targets", () => {
 test("shouldIgnoreGlobalEnter: typing or clicking should block global Enter action", () => {
   assert.equal(shouldIgnoreGlobalEnter({ tagName: "INPUT" }), true);
   assert.equal(shouldIgnoreGlobalEnter({ tagName: "BUTTON" }), true);
+  assert.equal(shouldIgnoreGlobalEnter({ tagName: "DIV", getAttribute: (k) => (k === "role" ? "textbox" : null) }), true);
   assert.equal(shouldIgnoreGlobalEnter({ tagName: "DIV" }), false);
 });
 


### PR DESCRIPTION
### What\nPrevents the overlay’s global Enter hotkey from firing while focus is in custom (ARIA-role) text inputs.\n\n### Why\nSome UIs render inputs as <div role="textbox"> etc. Without this guard, pressing Enter can accidentally trigger "Back on track" while typing.\n\n### Changes\n- Treat role="textbox"/"searchbox"/"combobox" as text input targets\n- Extend closest() selector list for accurate targeting\n- Add unit tests in overlay-utils.test.js\n\n### Test\n- npm --prefix overlay test\n- npm --prefix overlay run lint