### PR TITLE
overlay: ignore global Enter on contenteditable attribute

### DIFF
--- a/overlay/overlay-utils.js
+++ b/overlay/overlay-utils.js
@@ -8,7 +8,12 @@
   function isTextInputTarget(target) {
     if (!target) return false;
     const tag = String(target.tagName || "").toLowerCase();
-    if (target.isContentEditable) return true;
+
+    // In real DOM nodes, `isContentEditable` covers contenteditable regions.
+    // In tests or some wrappers, we may only have the attribute.
+    const contentEditableAttr = String(target.getAttribute?.("contenteditable") || "").toLowerCase();
+    if (target.isContentEditable || contentEditableAttr === "true") return true;
+
     return tag === "input" || tag === "textarea" || tag === "select";
   }
 

--- a/overlay/overlay-utils.test.js
+++ b/overlay/overlay-utils.test.js
@@ -8,6 +8,7 @@ test("isTextInputTarget: recognizes common typing targets", () => {
   assert.equal(isTextInputTarget({ tagName: "textarea" }), true);
   assert.equal(isTextInputTarget({ tagName: "Select" }), true);
   assert.equal(isTextInputTarget({ tagName: "DIV", isContentEditable: true }), true);
+  assert.equal(isTextInputTarget({ tagName: "DIV", getAttribute: (k) => (k === "contenteditable" ? "true" : null) }), true);
 });
 
 test("isTextInputTarget: ignores non-input targets", () => {


### PR DESCRIPTION
Small hotkey safety fix: treat elements with contenteditable="true" as text input targets, so the overlay's global Enter handler won't accidentally mark ‘Back on track’ while the user is typing in an editable region.\n\nAdds a unit test in overlay-utils.test.js.