### PR TITLE
overlay-utils: ignore global Enter on aria textbox/combobox

### DIFF
--- a/overlay/overlay-utils.js
+++ b/overlay/overlay-utils.js
@@ -7,8 +7,13 @@
 })(typeof globalThis !== "undefined" ? globalThis : this, function () {
   function isTextInputTarget(target) {
     if (!target) return false;
+
     const tag = String(target.tagName || "").toLowerCase();
     if (target.isContentEditable) return true;
+
+    const role = String(target.getAttribute?.("role") || "").toLowerCase();
+    if (role === "textbox" || role === "combobox") return true;
+
     return tag === "input" || tag === "textarea" || tag === "select";
   }
 
@@ -28,7 +33,7 @@
     // element that should "own" the keyboard interaction.
     if (typeof target.closest === "function") {
       const hit = target.closest(
-        'input,textarea,select,[contenteditable="true"],button,a,[role="button"],[role="link"]'
+        'input,textarea,select,[contenteditable],[contenteditable="true"],[role="textbox"],[role="combobox"],button,a,[role="button"],[role="link"]'
       );
       if (hit) return hit;
     }

--- a/overlay/overlay-utils.test.js
+++ b/overlay/overlay-utils.test.js
@@ -8,6 +8,8 @@ test("isTextInputTarget: recognizes common typing targets", () => {
   assert.equal(isTextInputTarget({ tagName: "textarea" }), true);
   assert.equal(isTextInputTarget({ tagName: "Select" }), true);
   assert.equal(isTextInputTarget({ tagName: "DIV", isContentEditable: true }), true);
+  assert.equal(isTextInputTarget({ tagName: "DIV", getAttribute: (k) => (k === "role" ? "textbox" : null) }), true);
+  assert.equal(isTextInputTarget({ tagName: "DIV", getAttribute: (k) => (k === "role" ? "combobox" : null) }), true);
 });
 
 test("isTextInputTarget: ignores non-input targets", () => {
@@ -31,6 +33,7 @@ test("isInteractiveTarget: ignores non-interactive targets", () => {
 test("shouldIgnoreGlobalEnter: typing or clicking should block global Enter action", () => {
   assert.equal(shouldIgnoreGlobalEnter({ tagName: "INPUT" }), true);
   assert.equal(shouldIgnoreGlobalEnter({ tagName: "BUTTON" }), true);
+  assert.equal(shouldIgnoreGlobalEnter({ tagName: "DIV", getAttribute: (k) => (k === "role" ? "textbox" : null) }), true);
   assert.equal(shouldIgnoreGlobalEnter({ tagName: "DIV" }), false);
 });
 


### PR DESCRIPTION
Small hotkey safety tweak: treat aria role=textbox/combobox as typing targets so global Enter doesn't trigger "Back on track" while interacting with custom inputs. Adds unit test coverage.