### PR TITLE
Overlay: ignore global Enter inside editable widgets

### DIFF
--- a/overlay/overlay-utils.js
+++ b/overlay/overlay-utils.js
@@ -9,6 +9,11 @@
     if (!target) return false;
     const tag = String(target.tagName || "").toLowerCase();
     if (target.isContentEditable) return true;
+
+    // Some editable widgets (e.g. custom editors) expose a textbox role.
+    const role = String(target.getAttribute?.("role") || "").toLowerCase();
+    if (role === "textbox" || role === "combobox") return true;
+
     return tag === "input" || tag === "textarea" || tag === "select";
   }
 
@@ -28,7 +33,7 @@
     // element that should "own" the keyboard interaction.
     if (typeof target.closest === "function") {
       const hit = target.closest(
-        'input,textarea,select,[contenteditable="true"],button,a,[role="button"],[role="link"]'
+        'input,textarea,select,[contenteditable],[role="textbox"],[role="combobox"],button,a,[role="button"],[role="link"]'
       );
       if (hit) return hit;
     }

--- a/overlay/overlay-utils.test.js
+++ b/overlay/overlay-utils.test.js
@@ -8,6 +8,10 @@ test("isTextInputTarget: recognizes common typing targets", () => {
   assert.equal(isTextInputTarget({ tagName: "textarea" }), true);
   assert.equal(isTextInputTarget({ tagName: "Select" }), true);
   assert.equal(isTextInputTarget({ tagName: "DIV", isContentEditable: true }), true);
+  assert.equal(
+    isTextInputTarget({ tagName: "DIV", getAttribute: (k) => (k === "role" ? "textbox" : null) }),
+    true
+  );
 });
 
 test("isTextInputTarget: ignores non-input targets", () => {
@@ -45,4 +49,15 @@ test("shouldIgnoreGlobalEnter: child of button/link should still block global En
     }
   };
   assert.equal(shouldIgnoreGlobalEnter(spanInsideButton), true);
+});
+
+test("shouldIgnoreGlobalEnter: child of contenteditable should block global Enter", () => {
+  const editor = { tagName: "DIV", isContentEditable: true };
+  const spanInsideEditor = {
+    tagName: "SPAN",
+    closest: (selector) => {
+      return selector ? editor : null;
+    }
+  };
+  assert.equal(shouldIgnoreGlobalEnter(spanInsideEditor), true);
 });


### PR DESCRIPTION
### What\nPrevents the overlay’s global Enter hotkey from firing when focus is inside editable widgets that aren’t plain <input>/<textarea> (e.g. contenteditable, role="textbox").\n\n### Why\nInput focus safety: avoid accidental overlay actions when the user is typing or interacting with custom editors.\n\n### Tests\n- npm --prefix overlay test\n- npm --prefix overlay run lint