### PR TITLE
Overlay: ignore global Enter when focus is role=textbox/searchbox

### DIFF
--- a/overlay/overlay-utils.js
+++ b/overlay/overlay-utils.js
@@ -9,6 +9,11 @@
     if (!target) return false;
     const tag = String(target.tagName || "").toLowerCase();
     if (target.isContentEditable) return true;
+
+    // ARIA roles that imply text entry (common in custom components).
+    const role = String(target.getAttribute?.("role") || "").toLowerCase();
+    if (role === "textbox" || role === "searchbox") return true;
+
     return tag === "input" || tag === "textarea" || tag === "select";
   }
 
@@ -28,7 +33,7 @@
     // element that should "own" the keyboard interaction.
     if (typeof target.closest === "function") {
       const hit = target.closest(
-        'input,textarea,select,[contenteditable="true"],button,a,[role="button"],[role="link"]'
+        'input,textarea,select,[contenteditable="true"],[role="textbox"],[role="searchbox"],button,a,[role="button"],[role="link"]'
       );
       if (hit) return hit;
     }

--- a/overlay/overlay-utils.js
+++ b/overlay/overlay-utils.js
@@ -33,7 +33,7 @@
     // element that should "own" the keyboard interaction.
     if (typeof target.closest === "function") {
       const hit = target.closest(
-        'input,textarea,select,[contenteditable="true"],[role="textbox"],[role="searchbox"],button,a,[role="button"],[role="link"]'
+        'input,textarea,select,[contenteditable],[role="textbox"],[role="searchbox"],button,a,[role="button"],[role="link"]'
       );
       if (hit) return hit;
     }

--- a/overlay/overlay-utils.test.js
+++ b/overlay/overlay-utils.test.js
@@ -8,6 +8,8 @@ test("isTextInputTarget: recognizes common typing targets", () => {
   assert.equal(isTextInputTarget({ tagName: "textarea" }), true);
   assert.equal(isTextInputTarget({ tagName: "Select" }), true);
   assert.equal(isTextInputTarget({ tagName: "DIV", isContentEditable: true }), true);
+  assert.equal(isTextInputTarget({ tagName: "DIV", getAttribute: (k) => (k === "role" ? "textbox" : null) }), true);
+  assert.equal(isTextInputTarget({ tagName: "DIV", getAttribute: (k) => (k === "role" ? "searchbox" : null) }), true);
 });
 
 test("isTextInputTarget: ignores non-input targets", () => {

--- a/overlay/overlay-utils.test.js
+++ b/overlay/overlay-utils.test.js
@@ -60,3 +60,12 @@ test("shouldIgnoreGlobalEnter: child of role=textbox should still block global E
   };
   assert.equal(shouldIgnoreGlobalEnter(child), true);
 });
+
+test("shouldIgnoreGlobalEnter: child of contenteditable should still block global Enter", () => {
+  const editable = { tagName: "DIV", isContentEditable: true };
+  const child = {
+    tagName: "SPAN",
+    closest: (selector) => (selector ? editable : null)
+  };
+  assert.equal(shouldIgnoreGlobalEnter(child), true);
+});

--- a/overlay/overlay-utils.test.js
+++ b/overlay/overlay-utils.test.js
@@ -33,6 +33,9 @@ test("isInteractiveTarget: ignores non-interactive targets", () => {
 test("shouldIgnoreGlobalEnter: typing or clicking should block global Enter action", () => {
   assert.equal(shouldIgnoreGlobalEnter({ tagName: "INPUT" }), true);
   assert.equal(shouldIgnoreGlobalEnter({ tagName: "BUTTON" }), true);
+  assert.equal(shouldIgnoreGlobalEnter({ tagName: "DIV", getAttribute: (k) => (k === "role" ? "textbox" : null) }), true);
+  assert.equal(shouldIgnoreGlobalEnter({ tagName: "DIV", getAttribute: (k) => (k === "role" ? "searchbox" : null) }), true);
+  assert.equal(shouldIgnoreGlobalEnter({ tagName: "DIV", getAttribute: (k) => (k === "role" ? "link" : null) }), true);
   assert.equal(shouldIgnoreGlobalEnter({ tagName: "DIV" }), false);
 });
 
@@ -47,4 +50,13 @@ test("shouldIgnoreGlobalEnter: child of button/link should still block global En
     }
   };
   assert.equal(shouldIgnoreGlobalEnter(spanInsideButton), true);
+});
+
+test("shouldIgnoreGlobalEnter: child of role=textbox should still block global Enter", () => {
+  const textbox = { tagName: "DIV", getAttribute: (k) => (k === "role" ? "textbox" : null) };
+  const child = {
+    tagName: "SPAN",
+    closest: (selector) => (selector ? textbox : null)
+  };
+  assert.equal(shouldIgnoreGlobalEnter(child), true);
 });


### PR DESCRIPTION
### Why\nCustom input components often use ARIA roles (textbox/searchbox) instead of native <input>. When focused, global Enter hotkeys should not trigger overlay actions.\n\n### What\n- Treat role="textbox" and role="searchbox" as text-entry targets for hotkey suppression\n- Extend closest() scan so nested spans inside such widgets still count\n- Add unit tests in overlay-utils.test.js\n\n### Verification\n- npm --prefix overlay test\n- npm --prefix overlay run lint (no lint configured)\n