### PR TITLE
Overlay: ignore global Enter for role="textbox" targets

### DIFF
--- a/overlay/overlay-utils.js
+++ b/overlay/overlay-utils.js
@@ -9,6 +9,10 @@
     if (!target) return false;
     const tag = String(target.tagName || "").toLowerCase();
     if (target.isContentEditable) return true;
+    const role = String(target.getAttribute?.("role") || "").toLowerCase();
+    // Some UI toolkits (and future overlay tweaks) may use a div with role="textbox".
+    // Treat it as typing context so global Enter doesn't trigger overlay actions.
+    if (role === "textbox") return true;
     return tag === "input" || tag === "textarea" || tag === "select";
   }
 

--- a/overlay/overlay-utils.test.js
+++ b/overlay/overlay-utils.test.js
@@ -8,6 +8,7 @@ test("isTextInputTarget: recognizes common typing targets", () => {
   assert.equal(isTextInputTarget({ tagName: "textarea" }), true);
   assert.equal(isTextInputTarget({ tagName: "Select" }), true);
   assert.equal(isTextInputTarget({ tagName: "DIV", isContentEditable: true }), true);
+  assert.equal(isTextInputTarget({ tagName: "DIV", getAttribute: (k) => (k === "role" ? "textbox" : null) }), true);
 });
 
 test("isTextInputTarget: ignores non-input targets", () => {


### PR DESCRIPTION
Small input-safety tweak: treat role="textbox" elements as typing contexts so the overlay's global Enter handler can't accidentally mark "Back on track" while the user is typing in an ARIA textbox.\n\n- Adds role="textbox" handling in overlay-utils\n- Adds unit test in overlay-utils.test.js\n\nTests: npm --prefix overlay test