### PR TITLE
Overlay: treat role="textbox" as text input for Enter guard

### DIFF
--- a/overlay/overlay-utils.js
+++ b/overlay/overlay-utils.js
@@ -9,6 +9,11 @@
     if (!target) return false;
     const tag = String(target.tagName || "").toLowerCase();
     if (target.isContentEditable) return true;
+
+    // Some UI libraries use role="textbox" on non-input elements.
+    const role = String(target.getAttribute?.("role") || "").toLowerCase();
+    if (role === "textbox") return true;
+
     return tag === "input" || tag === "textarea" || tag === "select";
   }
 

--- a/overlay/overlay-utils.test.js
+++ b/overlay/overlay-utils.test.js
@@ -8,6 +8,7 @@ test("isTextInputTarget: recognizes common typing targets", () => {
   assert.equal(isTextInputTarget({ tagName: "textarea" }), true);
   assert.equal(isTextInputTarget({ tagName: "Select" }), true);
   assert.equal(isTextInputTarget({ tagName: "DIV", isContentEditable: true }), true);
+  assert.equal(isTextInputTarget({ tagName: "DIV", getAttribute: (k) => (k === "role" ? "textbox" : null) }), true);
 });
 
 test("isTextInputTarget: ignores non-input targets", () => {


### PR DESCRIPTION
Small UX safety fix: treat role="textbox" elements as text input targets so the overlay's global Enter hotkey won't accidentally trigger actions while the user is typing in a custom textbox.\n\n- Updates overlay-utils isTextInputTarget\n- Adds unit test\n\nTests: npm --prefix overlay test