### PR TITLE
Test: cover role=link/button interactive targets

### DIFF
--- a/overlay/overlay-utils.test.js
+++ b/overlay/overlay-utils.test.js
@@ -20,6 +20,7 @@ test("isInteractiveTarget: recognizes common clickable targets", () => {
   assert.equal(isInteractiveTarget({ tagName: "BUTTON" }), true);
   assert.equal(isInteractiveTarget({ tagName: "a" }), true);
   assert.equal(isInteractiveTarget({ tagName: "DIV", getAttribute: (k) => (k === "role" ? "button" : null) }), true);
+  assert.equal(isInteractiveTarget({ tagName: "DIV", getAttribute: (k) => (k === "role" ? "link" : null) }), true);
 });
 
 test("isInteractiveTarget: ignores non-interactive targets", () => {
@@ -45,4 +46,17 @@ test("shouldIgnoreGlobalEnter: child of button/link should still block global En
     }
   };
   assert.equal(shouldIgnoreGlobalEnter(spanInsideButton), true);
+});
+
+test("shouldIgnoreGlobalEnter: respects role=button/link even when target is a child", () => {
+  const roleButton = { tagName: "DIV", getAttribute: (k) => (k === "role" ? "button" : null) };
+  const roleLink = { tagName: "DIV", getAttribute: (k) => (k === "role" ? "link" : null) };
+
+  const child = (hit) => ({
+    tagName: "SPAN",
+    closest: () => hit
+  });
+
+  assert.equal(shouldIgnoreGlobalEnter(child(roleButton)), true);
+  assert.equal(shouldIgnoreGlobalEnter(child(roleLink)), true);
 });


### PR DESCRIPTION
Adds unit coverage for overlay hotkey safety: role=link + child-of-role button/link should block global Enter action.