### PR TITLE
overlay-utils: treat role="textbox" as text input

### DIFF
--- a/overlay/overlay-utils.js
+++ b/overlay/overlay-utils.js
@@ -9,6 +9,12 @@
     if (!target) return false;
     const tag = String(target.tagName || "").toLowerCase();
     if (target.isContentEditable) return true;
+
+    // Some UIs (including our overlay) may use ARIA roles rather than native inputs.
+    // Treat role="textbox" as a typing target so global Enter/hotkeys don't fire.
+    const role = String(target.getAttribute?.("role") || "").toLowerCase();
+    if (role === "textbox") return true;
+
     return tag === "input" || tag === "textarea" || tag === "select";
   }
 

--- a/overlay/overlay-utils.test.js
+++ b/overlay/overlay-utils.test.js
@@ -8,6 +8,7 @@ test("isTextInputTarget: recognizes common typing targets", () => {
   assert.equal(isTextInputTarget({ tagName: "textarea" }), true);
   assert.equal(isTextInputTarget({ tagName: "Select" }), true);
   assert.equal(isTextInputTarget({ tagName: "DIV", isContentEditable: true }), true);
+  assert.equal(isTextInputTarget({ tagName: "DIV", getAttribute: (k) => (k === "role" ? "textbox" : null) }), true);
 });
 
 test("isTextInputTarget: ignores non-input targets", () => {


### PR DESCRIPTION
Fix global hotkey safety: treat ARIA role="textbox" as a typing target so Enter/hotkeys don’t trigger overlay actions while the user is editing.

- Adds unit test coverage in overlay-utils.test.js

Tests:
- npm --prefix overlay test