### PR TITLE
overlay: ignore global Enter when focus is ARIA textbox/searchbox

### DIFF
--- a/overlay/overlay-utils.js
+++ b/overlay/overlay-utils.js
@@ -35,7 +35,7 @@
     // element that should "own" the keyboard interaction.
     if (typeof target.closest === "function") {
       const hit = target.closest(
-        'input,textarea,select,[contenteditable="true"],button,a,[role="button"],[role="link"]'
+        'input,textarea,select,[contenteditable="true"],button,a,[role="button"],[role="link"],[role="textbox"],[role="searchbox"],[role="combobox"]'
       );
       if (hit) return hit;
     }

--- a/overlay/overlay-utils.js
+++ b/overlay/overlay-utils.js
@@ -8,7 +8,14 @@
   function isTextInputTarget(target) {
     if (!target) return false;
     const tag = String(target.tagName || "").toLowerCase();
+
+    // contentEditable elements behave like text inputs for our hotkey suppression purposes.
     if (target.isContentEditable) return true;
+
+    // Some UI libraries implement text inputs via divs + ARIA roles.
+    const role = String(target.getAttribute?.("role") || "").toLowerCase();
+    if (role === "textbox" || role === "searchbox" || role === "combobox") return true;
+
     return tag === "input" || tag === "textarea" || tag === "select";
   }
 

--- a/overlay/overlay-utils.test.js
+++ b/overlay/overlay-utils.test.js
@@ -8,6 +8,8 @@ test("isTextInputTarget: recognizes common typing targets", () => {
   assert.equal(isTextInputTarget({ tagName: "textarea" }), true);
   assert.equal(isTextInputTarget({ tagName: "Select" }), true);
   assert.equal(isTextInputTarget({ tagName: "DIV", isContentEditable: true }), true);
+  assert.equal(isTextInputTarget({ tagName: "DIV", getAttribute: (k) => (k === "role" ? "textbox" : null) }), true);
+  assert.equal(isTextInputTarget({ tagName: "DIV", getAttribute: (k) => (k === "role" ? "searchbox" : null) }), true);
 });
 
 test("isTextInputTarget: ignores non-input targets", () => {

--- a/overlay/overlay-utils.test.js
+++ b/overlay/overlay-utils.test.js
@@ -48,3 +48,15 @@ test("shouldIgnoreGlobalEnter: child of button/link should still block global En
   };
   assert.equal(shouldIgnoreGlobalEnter(spanInsideButton), true);
 });
+
+test("shouldIgnoreGlobalEnter: child of ARIA textbox should block global Enter", () => {
+  const textbox = { tagName: "DIV", getAttribute: (k) => (k === "role" ? "textbox" : null) };
+  const spanInsideTextbox = {
+    tagName: "SPAN",
+    closest: (selector) => {
+      return selector ? textbox : null;
+    }
+  };
+  assert.equal(shouldIgnoreGlobalEnter(spanInsideTextbox), true);
+});
+

--- a/overlay/overlay-utils.test.js
+++ b/overlay/overlay-utils.test.js
@@ -10,6 +10,7 @@ test("isTextInputTarget: recognizes common typing targets", () => {
   assert.equal(isTextInputTarget({ tagName: "DIV", isContentEditable: true }), true);
   assert.equal(isTextInputTarget({ tagName: "DIV", getAttribute: (k) => (k === "role" ? "textbox" : null) }), true);
   assert.equal(isTextInputTarget({ tagName: "DIV", getAttribute: (k) => (k === "role" ? "searchbox" : null) }), true);
+  assert.equal(isTextInputTarget({ tagName: "DIV", getAttribute: (k) => (k === "role" ? "combobox" : null) }), true);
 });
 
 test("isTextInputTarget: ignores non-input targets", () => {


### PR DESCRIPTION
Small focus-safety improvement: treat ARIA role=textbox/searchbox/combobox as typing targets, so global Enter doesn't accidentally trigger "Back on track".

- Adds overlay-utils tests for role=textbox/searchbox.

Tests:
- (cd overlay && npm test)