### PR TITLE
Overlay: ignore global Enter inside nested contenteditable

### DIFF
--- a/overlay/overlay-utils.js
+++ b/overlay/overlay-utils.js
@@ -28,7 +28,7 @@
     // element that should "own" the keyboard interaction.
     if (typeof target.closest === "function") {
       const hit = target.closest(
-        'input,textarea,select,[contenteditable="true"],button,a,[role="button"],[role="link"]'
+        'input,textarea,select,[contenteditable],[contenteditable=""],[contenteditable="true"],button,a,[role="button"],[role="link"]'
       );
       if (hit) return hit;
     }

--- a/overlay/overlay-utils.test.js
+++ b/overlay/overlay-utils.test.js
@@ -46,3 +46,15 @@ test("shouldIgnoreGlobalEnter: child of button/link should still block global En
   };
   assert.equal(shouldIgnoreGlobalEnter(spanInsideButton), true);
 });
+
+test("shouldIgnoreGlobalEnter: nested inside contenteditable should block global Enter", () => {
+  const contentEditableDiv = { tagName: "DIV", isContentEditable: true };
+  const child = {
+    tagName: "SPAN",
+    closest: (selector) => {
+      // Simulate a hit on the closest contenteditable ancestor.
+      return selector ? contentEditableDiv : null;
+    }
+  };
+  assert.equal(shouldIgnoreGlobalEnter(child), true);
+});


### PR DESCRIPTION
### Why
When focus is inside a contenteditable region (often via a nested child element), our global Enter hotkey could incorrectly fire because the closest() selector only matched `[contenteditable="true"]`.

### What
- Treat any contenteditable ancestor as a typing target for global Enter suppression.
- Add a unit test covering nested contenteditable focus.

### Tests
- `npm --prefix overlay test`
