### PR TITLE
overlay: ignore global Enter inside contenteditable

### DIFF
--- a/overlay/overlay-utils.js
+++ b/overlay/overlay-utils.js
@@ -28,7 +28,8 @@
     // element that should "own" the keyboard interaction.
     if (typeof target.closest === "function") {
       const hit = target.closest(
-        'input,textarea,select,[contenteditable="true"],button,a,[role="button"],[role="link"]'
+        // Note: [contenteditable] covers "true", "", and "plaintext-only".
+        'input,textarea,select,[contenteditable],button,a,[role="button"],[role="link"]'
       );
       if (hit) return hit;
     }

--- a/overlay/overlay-utils.test.js
+++ b/overlay/overlay-utils.test.js
@@ -46,3 +46,12 @@ test("shouldIgnoreGlobalEnter: child of button/link should still block global En
   };
   assert.equal(shouldIgnoreGlobalEnter(spanInsideButton), true);
 });
+
+test("shouldIgnoreGlobalEnter: child of contenteditable should block global Enter", () => {
+  const editable = { tagName: "DIV", isContentEditable: true };
+  const spanInsideEditable = {
+    tagName: "SPAN",
+    closest: (selector) => (selector ? editable : null)
+  };
+  assert.equal(shouldIgnoreGlobalEnter(spanInsideEditable), true);
+});


### PR DESCRIPTION
Fixes a hotkey focus-safety edge case: if the keydown target is inside a contenteditable region, global Enter should be ignored (so we don't accidentally mark Back on track).\n\n- Update closest() selector to match any [contenteditable] value (true/blank/plaintext-only).\n- Add unit test covering child-of-contenteditable scenario.\n\nTests: npm --prefix overlay test