### PR TITLE
Overlay: ignore global Enter in ARIA textbox/contenteditable

### DIFF
--- a/overlay/overlay-utils.js
+++ b/overlay/overlay-utils.js
@@ -8,7 +8,18 @@
   function isTextInputTarget(target) {
     if (!target) return false;
     const tag = String(target.tagName || "").toLowerCase();
+
+    // contenteditable can be: element.isContentEditable=true, or attribute present ("", "true").
     if (target.isContentEditable) return true;
+    const contentEditableAttr = target.getAttribute?.("contenteditable");
+    if (contentEditableAttr !== undefined && contentEditableAttr !== null && String(contentEditableAttr) !== "false") {
+      return true;
+    }
+
+    // ARIA textbox/combobox commonly used by custom inputs.
+    const role = String(target.getAttribute?.("role") || "").toLowerCase();
+    if (role === "textbox" || role === "combobox" || role === "searchbox") return true;
+
     return tag === "input" || tag === "textarea" || tag === "select";
   }
 
@@ -28,7 +39,7 @@
     // element that should "own" the keyboard interaction.
     if (typeof target.closest === "function") {
       const hit = target.closest(
-        'input,textarea,select,[contenteditable="true"],button,a,[role="button"],[role="link"]'
+        'input,textarea,select,[contenteditable],[role="textbox"],[role="combobox"],[role="searchbox"],button,a,[role="button"],[role="link"]'
       );
       if (hit) return hit;
     }

--- a/overlay/overlay-utils.test.js
+++ b/overlay/overlay-utils.test.js
@@ -8,6 +8,27 @@ test("isTextInputTarget: recognizes common typing targets", () => {
   assert.equal(isTextInputTarget({ tagName: "textarea" }), true);
   assert.equal(isTextInputTarget({ tagName: "Select" }), true);
   assert.equal(isTextInputTarget({ tagName: "DIV", isContentEditable: true }), true);
+  assert.equal(
+    isTextInputTarget({
+      tagName: "DIV",
+      getAttribute: (k) => (k === "contenteditable" ? "" : null)
+    }),
+    true
+  );
+  assert.equal(
+    isTextInputTarget({
+      tagName: "DIV",
+      getAttribute: (k) => (k === "role" ? "textbox" : null)
+    }),
+    true
+  );
+  assert.equal(
+    isTextInputTarget({
+      tagName: "DIV",
+      getAttribute: (k) => (k === "role" ? "combobox" : null)
+    }),
+    true
+  );
 });
 
 test("isTextInputTarget: ignores non-input targets", () => {


### PR DESCRIPTION
### Why
Prevent accidental global Enter actions (overlay hotkeys) while the user is typing into custom inputs (contenteditable or ARIA textbox-like widgets).

### What
- Treat the `contenteditable` attribute as a text input target (not just `isContentEditable`).
- Treat ARIA roles `textbox`, `combobox`, `searchbox` as text input targets.
- Extend the `closest()` selector used by `shouldIgnoreGlobalEnter` to include these roles and any `[contenteditable]`.

### Tests
- Updated `overlay-utils.test.js` to cover contenteditable attribute + ARIA roles.

Commands:
- `npm --prefix overlay test`
