### PR TITLE
Overlay: ignore global Enter when focused on ARIA inputs

### DIFF
--- a/overlay/overlay-utils.js
+++ b/overlay/overlay-utils.js
@@ -9,6 +9,12 @@
     if (!target) return false;
     const tag = String(target.tagName || "").toLowerCase();
     if (target.isContentEditable) return true;
+
+    // ARIA roles that represent a typing surface. This protects against treating Enter as a
+    // global "Back on track" hotkey while the user is interacting with custom inputs.
+    const role = String(target.getAttribute?.("role") || "").toLowerCase();
+    if (["textbox", "searchbox", "combobox", "spinbutton"].includes(role)) return true;
+
     return tag === "input" || tag === "textarea" || tag === "select";
   }
 
@@ -28,7 +34,7 @@
     // element that should "own" the keyboard interaction.
     if (typeof target.closest === "function") {
       const hit = target.closest(
-        'input,textarea,select,[contenteditable="true"],button,a,[role="button"],[role="link"]'
+        'input,textarea,select,[contenteditable="true"],button,a,[role="button"],[role="link"],[role="textbox"],[role="searchbox"],[role="combobox"],[role="spinbutton"]'
       );
       if (hit) return hit;
     }

--- a/overlay/overlay-utils.test.js
+++ b/overlay/overlay-utils.test.js
@@ -8,6 +8,7 @@ test("isTextInputTarget: recognizes common typing targets", () => {
   assert.equal(isTextInputTarget({ tagName: "textarea" }), true);
   assert.equal(isTextInputTarget({ tagName: "Select" }), true);
   assert.equal(isTextInputTarget({ tagName: "DIV", isContentEditable: true }), true);
+  assert.equal(isTextInputTarget({ tagName: "DIV", getAttribute: (k) => (k === "role" ? "textbox" : null) }), true);
 });
 
 test("isTextInputTarget: ignores non-input targets", () => {
@@ -31,6 +32,10 @@ test("isInteractiveTarget: ignores non-interactive targets", () => {
 test("shouldIgnoreGlobalEnter: typing or clicking should block global Enter action", () => {
   assert.equal(shouldIgnoreGlobalEnter({ tagName: "INPUT" }), true);
   assert.equal(shouldIgnoreGlobalEnter({ tagName: "BUTTON" }), true);
+  assert.equal(
+    shouldIgnoreGlobalEnter({ tagName: "DIV", getAttribute: (k) => (k === "role" ? "combobox" : null) }),
+    true
+  );
   assert.equal(shouldIgnoreGlobalEnter({ tagName: "DIV" }), false);
 });
 


### PR DESCRIPTION
## What\nPrevents the overlay's global Enter hotkey ("Back on track") from firing while focus is inside custom/ARIA input widgets (role="textbox"/"combobox"/etc.).\n\n## Why\nHelps eliminate accidental actions + improves input focus safety (Roadmap: stabilize overlay flow).\n\n## Tests\n- npm --prefix overlay test\n- npm --prefix overlay run lint (no lint configured)