### PR TITLE
Overlay: ignore global Enter in ARIA textbox/searchbox

### DIFF
--- a/overlay/overlay-utils.js
+++ b/overlay/overlay-utils.js
@@ -9,6 +9,12 @@
     if (!target) return false;
     const tag = String(target.tagName || "").toLowerCase();
     if (target.isContentEditable) return true;
+
+    // ARIA: treat textbox-like roles as typing targets.
+    // This protects against global Enter triggering overlay actions while the user is typing.
+    const role = String(target.getAttribute?.("role") || "").toLowerCase();
+    if (role === "textbox" || role === "searchbox") return true;
+
     return tag === "input" || tag === "textarea" || tag === "select";
   }
 
@@ -28,7 +34,7 @@
     // element that should "own" the keyboard interaction.
     if (typeof target.closest === "function") {
       const hit = target.closest(
-        'input,textarea,select,[contenteditable="true"],button,a,[role="button"],[role="link"]'
+        'input,textarea,select,[contenteditable="true"],button,a,[role="button"],[role="link"],[role="textbox"],[role="searchbox"]'
       );
       if (hit) return hit;
     }

--- a/overlay/overlay-utils.test.js
+++ b/overlay/overlay-utils.test.js
@@ -8,6 +8,8 @@ test("isTextInputTarget: recognizes common typing targets", () => {
   assert.equal(isTextInputTarget({ tagName: "textarea" }), true);
   assert.equal(isTextInputTarget({ tagName: "Select" }), true);
   assert.equal(isTextInputTarget({ tagName: "DIV", isContentEditable: true }), true);
+  assert.equal(isTextInputTarget({ tagName: "DIV", getAttribute: (k) => (k === "role" ? "textbox" : null) }), true);
+  assert.equal(isTextInputTarget({ tagName: "DIV", getAttribute: (k) => (k === "role" ? "searchbox" : null) }), true);
 });
 
 test("isTextInputTarget: ignores non-input targets", () => {
@@ -31,6 +33,7 @@ test("isInteractiveTarget: ignores non-interactive targets", () => {
 test("shouldIgnoreGlobalEnter: typing or clicking should block global Enter action", () => {
   assert.equal(shouldIgnoreGlobalEnter({ tagName: "INPUT" }), true);
   assert.equal(shouldIgnoreGlobalEnter({ tagName: "BUTTON" }), true);
+  assert.equal(shouldIgnoreGlobalEnter({ tagName: "DIV", getAttribute: (k) => (k === "role" ? "textbox" : null) }), true);
   assert.equal(shouldIgnoreGlobalEnter({ tagName: "DIV" }), false);
 });
 


### PR DESCRIPTION
Small safety improvement: treat role=textbox/searchbox as typing targets so global Enter hotkey doesn't fire overlay actions while user is typing. Adds unit tests in overlay-utils.test.js.